### PR TITLE
Fixed bug when empty app-email settings caused fail Student/Mentor creation

### DIFF
--- a/CharlieBackend.Api/Controllers/StudentsController.cs
+++ b/CharlieBackend.Api/Controllers/StudentsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using System;
 
 namespace CharlieBackend.Api.Controllers
 {
@@ -32,14 +33,19 @@ namespace CharlieBackend.Api.Controllers
                 return BadRequest();
             }
 
-            //var isEmailTaken = await _accountService.IsEmailTakenAsync(studentModel.Email);
-            //if (isEmailTaken) return StatusCode(409, "Account already exists!");
             var foundStudent = await _studentService
                     .GetStudentByEmailAsync(studentModel.Email);
 
             if (foundStudent != null)
             {
                 return Ok(foundStudent.Id);
+            }
+
+            var isEmailTaken = await _accountService.IsEmailTakenAsync(studentModel.Email);
+
+            if (isEmailTaken)
+            {
+                return StatusCode(409, "Account with this email already exists!");
             }
 
             var createdStudentModel = await _studentService
@@ -91,7 +97,7 @@ namespace CharlieBackend.Api.Controllers
 
                 return Ok(studentsModels);
             }
-            catch 
+            catch
             { 
                 return StatusCode(500); 
             }

--- a/CharlieBackend.Api/appsettings.json
+++ b/CharlieBackend.Api/appsettings.json
@@ -8,16 +8,16 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "server=localhost;port=3306;database=soft;uid=root;pwd=qwerty12345"
+    "DefaultConnection": "server=localhost;port=3306;database=soft;uid=root;pwd=disokno1"
   },
   "AuthOptions": {
     "ISSUER": "MyAuthServer",
     "AUDIENCE": "MyAuthClient",
     "KEY": "mysupersecret_secretkey!123",
-    "LIFETIME": "1"
+    "LIFETIME": "720"
   },
   "CredentialsSendersSettings": {
     "email": "sober607@gmail.com",
-    "password": "  "
+    "password": ""
   }
 }

--- a/CharlieBackend.Business/Services/Interfaces/ICredentialsSenderService.cs
+++ b/CharlieBackend.Business/Services/Interfaces/ICredentialsSenderService.cs
@@ -4,6 +4,6 @@ namespace CharlieBackend.Business.Services.Interfaces
 {
     public interface ICredentialsSenderService
     {
-        public Task SendCredentialsAsync(string email, string password);
+        public Task<bool> SendCredentialsAsync(string email, string password);
     }
 }

--- a/CharlieBackend.Business/Services/StudentService.cs
+++ b/CharlieBackend.Business/Services/StudentService.cs
@@ -3,6 +3,7 @@ using CharlieBackend.Core;
 using CharlieBackend.Core.Entities;
 using CharlieBackend.Core.Models.Student;
 using CharlieBackend.Data.Repositories.Impl.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -44,23 +45,32 @@ namespace CharlieBackend.Business.Services
 
                     await _unitOfWork.CommitAsync();
 
-                    //var newAccount = await _accountService.CreateAccountAsync(account.ToAccountModel());
+                    var credentialMessageSent = false;
 
-                    //var student = new Student { AccountId = newAccount.Id };
-                    //_unitOfWork.StudentRepository.Add(student);
+                    if (await _credentialSender.SendCredentialsAsync(account.Email, generatedPassword))
+                    {
+                        await transaction.CommitAsync();
 
-                    //await _unitOfWork.CommitAsync();
+                        credentialMessageSent = true;
 
+                        return student.ToStudentModel();
+                    }
+                    else
+                    {
+                        //Have to implement here sending error message or details to calling method/controller
+                        //throw new Exception("Email has not been sent");
 
-                    //await _unitOfWork.CommitAsync();
+                        await transaction.CommitAsync();
 
-                    await _credentialSender.SendCredentialsAsync(account.Email, generatedPassword);
-                    await transaction.CommitAsync();
+                        credentialMessageSent = false;
 
-                    return student.ToStudentModel();
+                        return student.ToStudentModel();
+                    }
+
                 }
                 catch
                 {
+                    //Have to implement here sending error message or details to calling method/controller
                     transaction.Rollback();
                     return null;
                 }


### PR DESCRIPTION
Fixed bug: when empty app-email settings caused fail in Student/Mentor creation. 
1) Added null/empty string check in EmailCredentialsSenderService.
2) Changed if SendCredentialsAsync sent mail succesfuly, returns TRUE, ortherwise false
3) Added in CreateStudentAsync,  bool variable "credentialMessageSent" to ba able in future to send to CONTROLLER status is message sent or not, to inform user.